### PR TITLE
mbedos: network: hack the ARMCC compilation to succeed

### DIFF
--- a/Source/Port/Reference-Impl/mbedOS/Networking/pal_plat_network.cpp
+++ b/Source/Port/Reference-Impl/mbedOS/Networking/pal_plat_network.cpp
@@ -530,6 +530,9 @@ void palSelectCallback7()
 palSelectCallbackFunction_t s_palSelectPalCallbackFunctions[PAL_NET_SOCKET_SELECT_MAX_SOCKETS] = { palSelectCallback0, palSelectCallback1, palSelectCallback2, palSelectCallback3, palSelectCallback4, palSelectCallback5, palSelectCallback6, palSelectCallback7 };
 
 
+void palSelectCallbackDummy()
+{
+}
 
 palStatus_t pal_plat_socketMiniSelect(const palSocket_t socketsToCheck[PAL_NET_SOCKET_SELECT_MAX_SOCKETS], uint32_t numberOfSockets, pal_timeVal_t* timeout,
 	uint8_t palSocketStatus[PAL_NET_SOCKET_SELECT_MAX_SOCKETS], uint32_t * numberOfSocketsSet)
@@ -607,8 +610,9 @@ palStatus_t pal_plat_socketMiniSelect(const palSocket_t socketsToCheck[PAL_NET_S
 
 		 for (index = 0; index < numberOfSockets; index++)
 		 {
+			 
 			 Socket* socketObj = (Socket*)socketsToCheck[index];
-			 socketObj->attach(NULL);
+			 socketObj->attach(palSelectCallbackDummy);
 		 }
 		 return result ;
 }


### PR DESCRIPTION
The code fails to compile on ARMCC 5.06 update 3 (build 300).
Add a hacky and ugly dummy method which is used instead of NULL
callback.

Error report being fixed:
---8<----8<----8<----
Compile: pal_plat_network.cpp
[Warning] pal_plat_network.cpp@463,0:  #177-D: variable "index"
was declared but never referenced
[ERROR] "pal/Source/Port/Reference-Impl/mbedOS/Networking/pal_plat_network.cpp",
line 463: Warning:  #177-D: variable "index" was declared but never referenced
"no source": Error:  #158: expression must be an lvalue or a function designator
./pal/Source/Port/Reference-Impl/mbedOS/Networking/pal_plat_network.cpp: 1 warning,
1 error

[mbed] ERROR: "python" returned error code 1.
---8<----8<----8<----
