### PR TITLE
Adding parameter sanity checks for socket parameter in pal_network.c methods

### DIFF
--- a/Source/PAL-Impl/Modules/Networking/pal_network.c
+++ b/Source/PAL-Impl/Modules/Networking/pal_network.c
@@ -192,7 +192,7 @@ palStatus_t pal_socket(palSocketDomain_t domain, palSocketType_t type, bool nonB
 palStatus_t pal_getSocketOptions(palSocket_t socket, palSocketOptionName_t optionName, void* optionValue, palSocketLength_t* optionLength)
 {
     palStatus_t result = PAL_SUCCESS;
-    if ((NULL == optionValue) || (NULL == optionLength))
+    if ((NULL == optionValue) || (NULL == optionLength) || (NULL == socket ))
     {
         return PAL_ERR_RTOS_PARAMETER;
     }
@@ -204,7 +204,7 @@ palStatus_t pal_getSocketOptions(palSocket_t socket, palSocketOptionName_t optio
 palStatus_t pal_setSocketOptions(palSocket_t socket, int optionName, const void* optionValue, palSocketLength_t optionLength)
 {
     palStatus_t result = PAL_SUCCESS;
-    if (NULL == optionValue)
+    if ((NULL == optionValue) || (NULL == socket ))
     {
         return PAL_ERR_RTOS_PARAMETER;
     }
@@ -216,7 +216,7 @@ palStatus_t pal_setSocketOptions(palSocket_t socket, int optionName, const void*
 palStatus_t pal_bind(palSocket_t socket, palSocketAddress_t* myAddress, palSocketLength_t addressLength)
 {
     palStatus_t result = PAL_SUCCESS;
-    if (NULL == myAddress)
+    if ((NULL == myAddress) || (NULL == socket ))
     {
         return PAL_ERR_RTOS_PARAMETER;
     }
@@ -228,7 +228,7 @@ palStatus_t pal_bind(palSocket_t socket, palSocketAddress_t* myAddress, palSocke
 palStatus_t pal_receiveFrom(palSocket_t socket, void* buffer, size_t length, palSocketAddress_t* from, palSocketLength_t* fromLength, size_t* bytesReceived)
 {
     palStatus_t result = PAL_SUCCESS;
-    if ((NULL == buffer) || (NULL == bytesReceived))
+    if ((NULL == buffer) || (NULL == bytesReceived) || (NULL == socket ))
     {
         return PAL_ERR_RTOS_PARAMETER;
     }
@@ -240,7 +240,7 @@ palStatus_t pal_receiveFrom(palSocket_t socket, void* buffer, size_t length, pal
 palStatus_t pal_sendTo(palSocket_t socket, const void* buffer, size_t length, const palSocketAddress_t* to, palSocketLength_t toLength, size_t* bytesSent)
 {
     palStatus_t result = PAL_SUCCESS;
-    if ((NULL == buffer) || (NULL == bytesSent) || (NULL == to))
+    if ((NULL == buffer) || (NULL == bytesSent) || (NULL == to) || (NULL == socket ))
     {
         return PAL_ERR_RTOS_PARAMETER;
     }


### PR DESCRIPTION
By this change we are adding parameter sanity checks to some methods of pal_network.c
It is motivated by the fact that in some conditions it might happen that the socket provided is actually NULL, and then the call on, for instance pal_plat_sendTo, will cast the NULL pointer to a UDPSocket pointer (https://github.com/ARMmbed/pal/blob/4e46c0ea870631bb5bec3e4aa9fd7eebf3db21f0/Source/Port/Reference-Impl/mbedOS/Networking/pal_plat_network.cpp#L424).
How to handle this whole stuff?
Where is it supposed to perform the checks for existing parameters?
Or is it that we should do sanity checks in https://github.com/ARMmbed/pal/blob/4e46c0ea870631bb5bec3e4aa9fd7eebf3db21f0/Source/Port/Reference-Impl/mbedOS/Networking/pal_plat_network.cpp#L424 itself?


FYI: @MarceloSalazar @karsev @markus-becker-tridonic-com

Related to issue on mbed-os: https://github.com/ARMmbed/mbed-os/issues/3130